### PR TITLE
Removed auto-adding of slash to path in Client

### DIFF
--- a/Sources/HTTP/Client/Client.swift
+++ b/Sources/HTTP/Client/Client.swift
@@ -21,7 +21,7 @@ extension ClientProtocol {
 extension ClientProtocol {
     public func request(_ method: Method, path: String, headers: [HeaderKey: String] = [:], query: [String: CustomStringConvertible] = [:], body: Body = []) throws -> Response {
         // TODO: Move finish("/") to initializer
-        var uri = URI(scheme: scheme, userInfo: nil, host: host, port: port, path: path.finished(with: "/"), query: nil, fragment: nil)
+        var uri = URI(scheme: scheme, userInfo: nil, host: host, port: port, path: path, query: nil, fragment: nil)
         uri.append(query: query)
         let request = Request(method: method, uri: uri, version: Version(major: 1, minor: 1), headers: headers, body: body)
         return try respond(to: request)


### PR DESCRIPTION
All paths were getting an extra slash added at the end, which caused issues with URLs which should not have a slash. I think the path should not be modified after being passed in.

/cc @LoganWright 